### PR TITLE
Reinstate --bundle-file argument to 'docker deploy'

### DIFF
--- a/cli/command/bundlefile/bundlefile.go
+++ b/cli/command/bundlefile/bundlefile.go
@@ -1,0 +1,69 @@
+package bundlefile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Bundlefile stores the contents of a bundlefile
+type Bundlefile struct {
+	Version  string
+	Services map[string]Service
+}
+
+// Service is a service from a bundlefile
+type Service struct {
+	Image      string
+	Command    []string          `json:",omitempty"`
+	Args       []string          `json:",omitempty"`
+	Env        []string          `json:",omitempty"`
+	Labels     map[string]string `json:",omitempty"`
+	Ports      []Port            `json:",omitempty"`
+	WorkingDir *string           `json:",omitempty"`
+	User       *string           `json:",omitempty"`
+	Networks   []string          `json:",omitempty"`
+}
+
+// Port is a port as defined in a bundlefile
+type Port struct {
+	Protocol string
+	Port     uint32
+}
+
+// LoadFile loads a bundlefile from a path to the file
+func LoadFile(reader io.Reader) (*Bundlefile, error) {
+	bundlefile := &Bundlefile{}
+
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(bundlefile); err != nil {
+		switch jsonErr := err.(type) {
+		case *json.SyntaxError:
+			return nil, fmt.Errorf(
+				"JSON syntax error at byte %v: %s",
+				jsonErr.Offset,
+				jsonErr.Error())
+		case *json.UnmarshalTypeError:
+			return nil, fmt.Errorf(
+				"Unexpected type at byte %v. Expected %s but received %s.",
+				jsonErr.Offset,
+				jsonErr.Type,
+				jsonErr.Value)
+		}
+		return nil, err
+	}
+
+	return bundlefile, nil
+}
+
+// Print writes the contents of the bundlefile to the output writer
+// as human readable json
+func Print(out io.Writer, bundle *Bundlefile) error {
+	bytes, err := json.MarshalIndent(*bundle, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	_, err = out.Write(bytes)
+	return err
+}

--- a/cli/command/bundlefile/bundlefile_test.go
+++ b/cli/command/bundlefile/bundlefile_test.go
@@ -1,0 +1,77 @@
+package bundlefile
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+func TestLoadFileV01Success(t *testing.T) {
+	reader := strings.NewReader(`{
+		"Version": "0.1",
+		"Services": {
+			"redis": {
+				"Image": "redis@sha256:4b24131101fa0117bcaa18ac37055fffd9176aa1a240392bb8ea85e0be50f2ce",
+				"Networks": ["default"]
+			},
+			"web": {
+				"Image": "dockercloud/hello-world@sha256:fe79a2cfbd17eefc344fb8419420808df95a1e22d93b7f621a7399fd1e9dca1d",
+				"Networks": ["default"],
+				"User": "web"
+			}
+		}
+	}`)
+
+	bundle, err := LoadFile(reader)
+	assert.NilError(t, err)
+	assert.Equal(t, bundle.Version, "0.1")
+	assert.Equal(t, len(bundle.Services), 2)
+}
+
+func TestLoadFileSyntaxError(t *testing.T) {
+	reader := strings.NewReader(`{
+		"Version": "0.1",
+		"Services": unquoted string
+	}`)
+
+	_, err := LoadFile(reader)
+	assert.Error(t, err, "syntax error at byte 37: invalid character 'u'")
+}
+
+func TestLoadFileTypeError(t *testing.T) {
+	reader := strings.NewReader(`{
+		"Version": "0.1",
+		"Services": {
+			"web": {
+				"Image": "redis",
+				"Networks": "none"
+			}
+		}
+	}`)
+
+	_, err := LoadFile(reader)
+	assert.Error(t, err, "Unexpected type at byte 94. Expected []string but received string")
+}
+
+func TestPrint(t *testing.T) {
+	var buffer bytes.Buffer
+	bundle := &Bundlefile{
+		Version: "0.1",
+		Services: map[string]Service{
+			"web": {
+				Image:   "image",
+				Command: []string{"echo", "something"},
+			},
+		},
+	}
+	assert.NilError(t, Print(&buffer, bundle))
+	output := buffer.String()
+	assert.Contains(t, output, "\"Image\": \"image\"")
+	assert.Contains(t, output,
+		`"Command": [
+                "echo",
+                "something"
+            ]`)
+}

--- a/cli/command/stack/opts.go
+++ b/cli/command/stack/opts.go
@@ -1,11 +1,48 @@
 package stack
 
-import "github.com/spf13/pflag"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/docker/cli/command/bundlefile"
+	"github.com/spf13/pflag"
+)
 
 func addComposefileFlag(opt *string, flags *pflag.FlagSet) {
 	flags.StringVar(opt, "compose-file", "", "Path to a Compose file")
 }
 
+func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
+	flags.StringVar(opt, "bundle-file", "", "Path to a Distributed Application Bundle file")
+}
+
 func addRegistryAuthFlag(opt *bool, flags *pflag.FlagSet) {
 	flags.BoolVar(opt, "with-registry-auth", false, "Send registry authentication details to Swarm agents")
+}
+
+func loadBundlefile(stderr io.Writer, namespace string, path string) (*bundlefile.Bundlefile, error) {
+	defaultPath := fmt.Sprintf("%s.dab", namespace)
+
+	if path == "" {
+		path = defaultPath
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf(
+			"Bundle %s not found. Specify the path with --file",
+			path)
+	}
+
+	fmt.Fprintf(stderr, "Loading bundle from %s\n", path)
+	reader, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	bundle, err := bundlefile.LoadFile(reader)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s: %v\n", path, err)
+	}
+	return bundle, err
 }


### PR DESCRIPTION
1. `convertNetworks` has been renamed to `convertServiceNetworks` for clarity.

2. The `createNetworks` and `deployServices` functions are now agnostic of what file was used to load configuration - they just take maps of the appropriate Swarm structs. Both `deployBundle` and `deployCompose` make use of them.

3. `convertNetworks` and `convertServices` are Compose-specific utility functions for `deployCompose` which produce the maps-of-structs mentioned above.
